### PR TITLE
Add historical data tracking and visualization features

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  fl_chart:
+    dependency: "direct main"
+    description:
+      name: fl_chart
+      sha256: "5276944c6ffc975ae796569a826c38a62d2abcf264e26b88fa6f482e107f4237"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.70.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   flutter_blue_plus: 1.35.2
   provider: 6.1.2
   permission_handler: 11.3.1
+  fl_chart: ^0.70.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a new feature to display historical PM sensor data in the Flutter application. The changes include adding a new screen for historical data, updating the state management to handle historical data, and integrating a chart library for data visualization.

### New Feature: Historical Data Display

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R1): Imported the `fl_chart` library to enable chart visualization.
* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R16): Added a new constant `historyCharUUID` for the historical data characteristic UUID.

### State Management Enhancements

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R49-R50): Updated `PMSensorState` class to include `historicalData` and `isLoadingHistory` properties, and added a method `updateHistoricalData` to update the historical data. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R49-R50) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R64-R207)

### New Historical Data Screen

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R64-R207): Created a new `HistoricalDataScreen` class to display historical PM sensor data using a line chart and a list of readings.

### Data Fetching and Navigation

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R291-R317): Added `_fetchHistoricalData` method in `HomePageState` to fetch historical data from the Bluetooth device and update the state.
* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R356-R357): Updated `_connect` method in `HomePageState` to fetch historical data after connecting to the device, and added a button to navigate to the `HistoricalDataScreen`. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R356-R357) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R420-R431)

### Dependency Update

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R40): Added `fl_chart` dependency for chart visualization.